### PR TITLE
fix implicit-fallthrough

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -173,6 +173,7 @@ static void parse_args(struct arguments* args, int argc, char *const argv[])
             if (print_usage) {
                 usage(EXIT_SUCCESS);
             }
+            break;
         case 'A':
             args->dnode_addr = strdup(optarg);
             if (!args->dnode_addr) {
@@ -187,6 +188,7 @@ static void parse_args(struct arguments* args, int argc, char *const argv[])
             break;
         case 'h':
             usage(EXIT_SUCCESS);
+            break;
         case 'I':
             args->sample_iface = optarg;
             break;

--- a/util/proto2bytes/main.c
+++ b/util/proto2bytes/main.c
@@ -133,6 +133,7 @@ static void parse_args(struct arguments* args, int argc, char *const argv[])
             if (print_usage) {
                 usage(EXIT_SUCCESS);
             }
+            break;
         case 'A':
             args->all_sub_channels = 1;
             break;

--- a/util/sampstreamer/main.c
+++ b/util/sampstreamer/main.c
@@ -132,6 +132,7 @@ static void parse_args(struct arguments* args, int argc, char *const argv[])
             if (print_usage) {
                 usage(EXIT_SUCCESS);
             }
+            break;
         case 'e':
             args->set_err = 1;
             break;

--- a/util/sata2hdf5/main.c
+++ b/util/sata2hdf5/main.c
@@ -146,6 +146,7 @@ static void parse_args(struct arguments* args, int argc, char *const argv[])
             if (print_usage) {
                 usage(EXIT_SUCCESS);
             }
+            break;
         case 'c':
             count = strtol(optarg, (char**)0, 10);
             if (count < 0) {


### PR DESCRIPTION
GCC 7 defaults to setting -Wimplicit-fallthrough when -Wextra is set, causing a pattern in the existing code base to trigger this warning, which is elevated to error by -Wall.

We fix instances of the pattern in this change.